### PR TITLE
Local docker build

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -41,8 +41,8 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      docker pull squidfunk/mkdocs-material
-      docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
+      echo -e "FROM squidfunk/mkdocs-material \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin" | docker build -t squidfunk/mkdocs-material -
+      docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material:latest build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -42,7 +42,7 @@ jobs:
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
       echo -e "FROM squidfunk/mkdocs-material \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin" | docker build -t squidfunk/mkdocs-material -
-      docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material:latest build
+      docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}


### PR DESCRIPTION
Version 6.0 of mkdocs [removed some plugins from the default image](https://github.com/squidfunk/mkdocs-material/commit/08318ac179db0d4fdf3c20fdca3e9051d2c34242#diff-3254677a7917c6c01f55212f86c57fbf).

The [provided instructions](https://squidfunk.github.io/mkdocs-material/getting-started/#with-docker) if you want to add plugins to the official image are to create a new dockerfile `FROM` the official image and `RUN pip install` to install any additional plugins.  To prevent requiring a Dockerfile in each documentation repo, this echos it to the pipeline and instructs docker build to receive the Dockerfile from STDIN.

This will use mkdocs material 6.x, which [might require changes to your mkdocs.yml or any custom HTML files.](https://squidfunk.github.io/mkdocs-material/upgrading/#upgrading-from-5x-to-6x)