### PR TITLE
No pat

### DIFF
--- a/PSModules/stages/build-module.yml
+++ b/PSModules/stages/build-module.yml
@@ -29,6 +29,8 @@ stages:
         - task: gitversion/execute@0
         - powershell: |
             gci env:
+          displayName: test environment
+          enabled: ${{ eq(variables['System.Debug'], 'True') }}
         - powershell: |
             # A valid Nuget version allows a hyphen in the prerelease string, and on a pull request build,
             # the gitversion generated nuget version will have a hyphen in the prerelease string (example: "1.2.8-pullrequest0003-0016")

--- a/PSModules/stages/deploy-module-publish-only.yml
+++ b/PSModules/stages/deploy-module-publish-only.yml
@@ -27,37 +27,17 @@ stages:
         inputs:
           artifactName: ${{ parameters.ModuleName }}
           targetPath: $(Build.ArtifactStagingDirectory)
-      - template: ../steps/deploy/register-psrepository-step.yml
-        parameters:
-          RepoPath: ${{ parameters.RepoPath }}
-          RepoName: ${{ parameters.RepoName }}
       - powershell: |
-          if ($env:SYSTEM_DEBUG -eq 'true') {
-            Write-Host "$(Agent.TempDirectory)"
-            gci "$(Agent.TempDirectory)"
-          }
-          $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
-          foreach ($req in $module.RequiredModules) {
-            Save-Module -Name $req -Path $(Agent.TempDirectory)
-          }
-        displayName: Download Module Dependencies
-      - powershell: |
-          $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          if ($env:SYSTEM_DEBUG -eq 'true') {
-            gci "$(Agent.TempDirectory)"
-          }
           $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           if ($test.PrivateData.PSData.Prerelease) {
             $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
           } else {
             $version = $test.Version.ToString()
           }
-          #$version = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1').ModuleVersion
-          Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
           Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
           Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"
-        displayName: Publish Module
-        name: PublishModule
+        displayName: Version Module
+        name: VersionModule
       - task: ArchiveFiles@2
         inputs:
           rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}'
@@ -93,9 +73,9 @@ stages:
           $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
 
           $body = @{
-            tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"
+            tag_name="v$env:VERSIONMODULE_PACKAGEVERSION"
             target_commitish= "$(Build.SourceVersion)"
-            name = "${{ parameters.ModuleName }} v$env:PUBLISHMODULE_PACKAGEVERSION"
+            name = "${{ parameters.ModuleName }} v$env:VERSIONMODULE_PACKAGEVERSION"
             } | ConvertTo-Json
           write-host $body
           ($release = Invoke-RestMethod -Uri $uri -Headers $ghHeader -Body $body -Method Post)
@@ -104,3 +84,25 @@ stages:
           ($asset = Invoke-RestMethod -Uri $uploadurl -Method Post -InFile '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip' -Headers $ghHeader -ContentType 'application/zip')
         displayName: Publish Release
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
+      - template: ../steps/deploy/register-psrepository-step.yml
+        parameters:
+          RepoPath: ${{ parameters.RepoPath }}
+          RepoName: ${{ parameters.RepoName }}
+      - powershell: |
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            Write-Host "$(Agent.TempDirectory)"
+            gci "$(Agent.TempDirectory)"
+          }
+          $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
+          foreach ($req in $module.RequiredModules) {
+            Save-Module -Name $req -Path $(Agent.TempDirectory)
+          }
+        displayName: Download Module Dependencies
+      - powershell: |
+          $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            gci "$(Agent.TempDirectory)"
+          }
+          Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
+        displayName: Publish Module
+        name: PublishModule

--- a/PSModules/stages/deploy-module-publish-only.yml
+++ b/PSModules/stages/deploy-module-publish-only.yml
@@ -32,7 +32,7 @@ stages:
           RepoPath: ${{ parameters.RepoPath }}
           RepoName: ${{ parameters.RepoName }}
       - powershell: |
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             Write-Host "$(Agent.TempDirectory)"
             gci "$(Agent.TempDirectory)"
           }
@@ -43,7 +43,7 @@ stages:
         displayName: Download Module Dependencies
       - powershell: |
           $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             gci "$(Agent.TempDirectory)"
           }
           $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
@@ -66,18 +66,18 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             gci env:
             git --no-pager config --list
           }
 
           $repositoryUri = $Env:BUILD_REPOSITORY_URI
           $authKeyName = "http.$repositoryUri.extraheader"
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             write-host "auth key name $authKeyName"
           }
           $authKey = git config --get $authKeyName
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             write-host "auth key $authKey"
           }
 

--- a/PSModules/stages/deploy-module-publish-only.yml
+++ b/PSModules/stages/deploy-module-publish-only.yml
@@ -5,20 +5,24 @@ parameters:
   type: string
 - name: RepoName
   type: string
+- name: DefaultBranch
+  type: string
 - name: GitHubPAT
   type: string
 
 stages:
 - stage: Deploy
   dependsOn: Test
-  #condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
+  #condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
   jobs:
     - job: Publish
       pool: Default
       workspace:
         clean: all
       steps:
-      - checkout: none
+      - checkout: self
+        fetchDepth: 1
+        persistCredentials: true
       - task: DownloadPipelineArtifact@2
         inputs:
           artifactName: ${{ parameters.ModuleName }}
@@ -28,8 +32,10 @@ stages:
           RepoPath: ${{ parameters.RepoPath }}
           RepoName: ${{ parameters.RepoName }}
       - powershell: |
-          Write-Host "$(Agent.TempDirectory)"
-          gci "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            Write-Host "$(Agent.TempDirectory)"
+            gci "$(Agent.TempDirectory)"
+          }
           $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           foreach ($req in $module.RequiredModules) {
             Save-Module -Name $req -Path $(Agent.TempDirectory)
@@ -37,7 +43,9 @@ stages:
         displayName: Download Module Dependencies
       - powershell: |
           $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          gci "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            gci "$(Agent.TempDirectory)"
+          }
           $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           if ($test.PrivateData.PSData.Prerelease) {
             $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
@@ -56,13 +64,22 @@ stages:
           includeRootFolder: true
           archiveType: zip
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
-        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
-          gci env:
-          $auth = '${{ parameters.GitHubPAT }}'
-          $ghHeader = @{ Authorization = "Basic "+ [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($auth)) }
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            gci env:
+            git --no-pager config --list
+          }
 
           $repositoryUri = $Env:BUILD_REPOSITORY_URI
+          $authKeyName = "http.$repositoryUri.extraheader"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            write-host "auth key name $authKeyName"
+          }
+          $authKey = git config --get $authKeyName
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            write-host "auth key $authKey"
+          }
 
           $uribuilder = [System.UriBuilder]$repositoryUri
           if ($uribuilder.Host -eq "github.com") {
@@ -85,5 +102,4 @@ stages:
           $uploadurl = ($release.upload_url).Split('{')[0] + '?name=${{ parameters.ModuleName }}.zip'
           ($asset = Invoke-RestMethod -Uri $uploadurl -Method Post -InFile '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip' -Headers $ghHeader -ContentType 'application/zip')
         displayName: Publish Release
-        condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
-    
+        condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/PSModules/stages/deploy-module-publish-only.yml
+++ b/PSModules/stages/deploy-module-publish-only.yml
@@ -90,6 +90,7 @@ stages:
           $uribase = $uribuilder.Scheme + "://" + $ghHost + "/api/v3/"
 
           $uri = $uribase + "repos" + $uribuilder.Path + "/releases"
+          $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
 
           $body = @{
             tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -32,7 +32,7 @@ stages:
           RepoPath: ${{ parameters.RepoPath }}
           RepoName: ${{ parameters.RepoName }}
       - powershell: |
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             Write-Host "$(Agent.TempDirectory)"
             gci "$(Agent.TempDirectory)"
           }
@@ -43,7 +43,7 @@ stages:
         displayName: Download Module Dependencies
       - powershell: |
           $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             gci "$(Agent.TempDirectory)"
           }
           $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
@@ -66,18 +66,18 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             gci env:
             git --no-pager config --list
           }
 
           $repositoryUri = $Env:BUILD_REPOSITORY_URI
           $authKeyName = "http.$repositoryUri.extraheader"
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             write-host "auth key name $authKeyName"
           }
           $authKey = git config --get $authKeyName
-          if ($env:SYSTEM_DEBUG) -eq 'true') {
+          if ($env:SYSTEM_DEBUG -eq 'true') {
             write-host "auth key $authKey"
           }
 

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -27,37 +27,6 @@ stages:
         inputs:
           artifactName: ${{ parameters.ModuleName }}
           targetPath: $(Build.ArtifactStagingDirectory)
-      - template: ../steps/deploy/register-psrepository-step.yml
-        parameters:
-          RepoPath: ${{ parameters.RepoPath }}
-          RepoName: ${{ parameters.RepoName }}
-      - powershell: |
-          if ($env:SYSTEM_DEBUG -eq 'true') {
-            Write-Host "$(Agent.TempDirectory)"
-            gci "$(Agent.TempDirectory)"
-          }
-          $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
-          foreach ($req in $module.RequiredModules) {
-            Save-Module -Name $req -Path $(Agent.TempDirectory)
-          }
-        displayName: Download Module Dependencies
-      - powershell: |
-          $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          if ($env:SYSTEM_DEBUG -eq 'true') {
-            gci "$(Agent.TempDirectory)"
-          }
-          $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
-          if ($test.PrivateData.PSData.Prerelease) {
-            $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
-          } else {
-            $version = $test.Version.ToString()
-          }
-          #$version = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1').ModuleVersion
-          Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
-          Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
-          Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"
-        displayName: Publish Module
-        name: PublishModule
       - task: ArchiveFiles@2
         inputs:
           rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}'
@@ -104,6 +73,83 @@ stages:
           ($asset = Invoke-RestMethod -Uri $uploadurl -Method Post -InFile '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip' -Headers $ghHeader -ContentType 'application/zip')
         displayName: Publish Release
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
+      - template: ../steps/deploy/register-psrepository-step.yml
+        parameters:
+          RepoPath: ${{ parameters.RepoPath }}
+          RepoName: ${{ parameters.RepoName }}
+      - powershell: |
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            Write-Host "$(Agent.TempDirectory)"
+            gci "$(Agent.TempDirectory)"
+          }
+          $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
+          foreach ($req in $module.RequiredModules) {
+            Save-Module -Name $req -Path $(Agent.TempDirectory)
+          }
+        displayName: Download Module Dependencies
+      - powershell: |
+          $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            gci "$(Agent.TempDirectory)"
+          }
+          $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
+          if ($test.PrivateData.PSData.Prerelease) {
+            $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
+          } else {
+            $version = $test.Version.ToString()
+          }
+          #$version = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1').ModuleVersion
+          Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
+          Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
+          Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"
+        displayName: Publish Module
+        name: PublishModule
+      # - task: ArchiveFiles@2
+      #   inputs:
+      #     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}'
+      #     includeRootFolder: true
+      #     archiveType: zip
+      #     archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
+      #   condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
+      # - powershell: |
+      #     if ($env:SYSTEM_DEBUG -eq 'true') {
+      #       gci env:
+      #       git --no-pager config --list
+      #     }
+
+      #     $repositoryUri = $Env:BUILD_REPOSITORY_URI
+      #     $authKeyName = "http.$repositoryUri.extraheader"
+      #     if ($env:SYSTEM_DEBUG -eq 'true') {
+      #       write-host "auth key name $authKeyName"
+      #     }
+      #     $authKey = git config --get $authKeyName
+      #     if ($env:SYSTEM_DEBUG -eq 'true') {
+      #       write-host "auth key $authKey"
+      #     }
+
+      #     $uribuilder = [System.UriBuilder]$repositoryUri
+      #     if ($uribuilder.Host -eq "github.com") {
+      #         $ghHost = "api.github.com"
+      #     } else {
+      #         $ghHost = $uribuilder.Host
+      #     }
+      #     $uribase = $uribuilder.Scheme + "://" + $ghHost + "/api/v3/"
+
+      #     $uri = $uribase + "repos" + $uribuilder.Path + "/releases"
+      #     $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
+
+      #     $body = @{
+      #       tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"
+      #       target_commitish= "$(Build.SourceVersion)"
+      #       name = "${{ parameters.ModuleName }} v$env:PUBLISHMODULE_PACKAGEVERSION"
+      #       } | ConvertTo-Json
+      #     write-host $body
+      #     ($release = Invoke-RestMethod -Uri $uri -Headers $ghHeader -Body $body -Method Post)
+
+      #     $uploadurl = ($release.upload_url).Split('{')[0] + '?name=${{ parameters.ModuleName }}.zip'
+      #     ($asset = Invoke-RestMethod -Uri $uploadurl -Method Post -InFile '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip' -Headers $ghHeader -ContentType 'application/zip')
+      #   displayName: Publish Release
+      #   condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
     - deployment: Test
       dependsOn: Publish
       variables:

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -106,52 +106,6 @@ stages:
           Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
         displayName: Publish Module
         name: PublishModule
-      # - task: ArchiveFiles@2
-      #   inputs:
-      #     rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}'
-      #     includeRootFolder: true
-      #     archiveType: zip
-      #     archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
-      #   condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
-      # - powershell: |
-      #     if ($env:SYSTEM_DEBUG -eq 'true') {
-      #       gci env:
-      #       git --no-pager config --list
-      #     }
-
-      #     $repositoryUri = $Env:BUILD_REPOSITORY_URI
-      #     $authKeyName = "http.$repositoryUri.extraheader"
-      #     if ($env:SYSTEM_DEBUG -eq 'true') {
-      #       write-host "auth key name $authKeyName"
-      #     }
-      #     $authKey = git config --get $authKeyName
-      #     if ($env:SYSTEM_DEBUG -eq 'true') {
-      #       write-host "auth key $authKey"
-      #     }
-
-      #     $uribuilder = [System.UriBuilder]$repositoryUri
-      #     if ($uribuilder.Host -eq "github.com") {
-      #         $ghHost = "api.github.com"
-      #     } else {
-      #         $ghHost = $uribuilder.Host
-      #     }
-      #     $uribase = $uribuilder.Scheme + "://" + $ghHost + "/api/v3/"
-
-      #     $uri = $uribase + "repos" + $uribuilder.Path + "/releases"
-      #     $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
-
-      #     $body = @{
-      #       tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"
-      #       target_commitish= "$(Build.SourceVersion)"
-      #       name = "${{ parameters.ModuleName }} v$env:PUBLISHMODULE_PACKAGEVERSION"
-      #       } | ConvertTo-Json
-      #     write-host $body
-      #     ($release = Invoke-RestMethod -Uri $uri -Headers $ghHeader -Body $body -Method Post)
-
-      #     $uploadurl = ($release.upload_url).Split('{')[0] + '?name=${{ parameters.ModuleName }}.zip'
-      #     ($asset = Invoke-RestMethod -Uri $uploadurl -Method Post -InFile '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip' -Headers $ghHeader -ContentType 'application/zip')
-      #   displayName: Publish Release
-      #   condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
     - deployment: Test
       dependsOn: Publish
       variables:

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -90,6 +90,7 @@ stages:
           $uribase = $uribuilder.Scheme + "://" + $ghHost + "/api/v3/"
 
           $uri = $uribase + "repos" + $uribuilder.Path + "/releases"
+          $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
 
           $body = @{
             tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -20,7 +20,9 @@ stages:
       workspace:
         clean: all
       steps:
-      - checkout: none
+      - checkout: self
+        fetchDepth: 1
+        persistCredentials: true
       - task: DownloadPipelineArtifact@2
         inputs:
           artifactName: ${{ parameters.ModuleName }}
@@ -30,8 +32,10 @@ stages:
           RepoPath: ${{ parameters.RepoPath }}
           RepoName: ${{ parameters.RepoName }}
       - powershell: |
-          Write-Host "$(Agent.TempDirectory)"
-          gci "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            Write-Host "$(Agent.TempDirectory)"
+            gci "$(Agent.TempDirectory)"
+          }
           $module = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           foreach ($req in $module.RequiredModules) {
             Save-Module -Name $req -Path $(Agent.TempDirectory)
@@ -39,7 +43,9 @@ stages:
         displayName: Download Module Dependencies
       - powershell: |
           $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + "$(Agent.TempDirectory)"
-          gci "$(Agent.TempDirectory)"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            gci "$(Agent.TempDirectory)"
+          }
           $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           if ($test.PrivateData.PSData.Prerelease) {
             $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
@@ -60,11 +66,20 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
-          gci env:
-          $auth = '${{ parameters.GitHubPAT }}'
-          $ghHeader = @{ Authorization = "Basic "+ [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($auth)) }
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            gci env:
+            git --no-pager config --list
+          }
 
           $repositoryUri = $Env:BUILD_REPOSITORY_URI
+          $authKeyName = "http.$repositoryUri.extraheader"
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            write-host "auth key name $authKeyName"
+          }
+          $authKey = git config --get $authKeyName
+          if ($env:SYSTEM_DEBUG) -eq 'true') {
+            write-host "auth key $authKey"
+          }
 
           $uribuilder = [System.UriBuilder]$repositoryUri
           if ($uribuilder.Host -eq "github.com") {

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -27,6 +27,17 @@ stages:
         inputs:
           artifactName: ${{ parameters.ModuleName }}
           targetPath: $(Build.ArtifactStagingDirectory)
+      - powershell: |
+          $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
+          if ($test.PrivateData.PSData.Prerelease) {
+            $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
+          } else {
+            $version = $test.Version.ToString()
+          }
+          Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
+          Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"
+        displayName: Version Module
+        name: VersionModule
       - task: ArchiveFiles@2
         inputs:
           rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}'
@@ -62,9 +73,9 @@ stages:
           $ghHeader = @{ Authorization = $authKey.split(':').trim()[1] }
 
           $body = @{
-            tag_name="v$env:PUBLISHMODULE_PACKAGEVERSION"
+            tag_name="v$env:VERSIONMODULE_PACKAGEVERSION"
             target_commitish= "$(Build.SourceVersion)"
-            name = "${{ parameters.ModuleName }} v$env:PUBLISHMODULE_PACKAGEVERSION"
+            name = "${{ parameters.ModuleName }} v$env:VERSIONMODULE_PACKAGEVERSION"
             } | ConvertTo-Json
           write-host $body
           ($release = Invoke-RestMethod -Uri $uri -Headers $ghHeader -Body $body -Method Post)
@@ -92,16 +103,7 @@ stages:
           if ($env:SYSTEM_DEBUG -eq 'true') {
             gci "$(Agent.TempDirectory)"
           }
-          $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
-          if ($test.PrivateData.PSData.Prerelease) {
-            $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
-          } else {
-            $version = $test.Version.ToString()
-          }
-          #$version = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1').ModuleVersion
           Publish-Module -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*' -Repository '${{ parameters.RepoName }}' -Force
-          Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
-          Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"
         displayName: Publish Module
         name: PublishModule
       # - task: ArchiveFiles@2
@@ -153,7 +155,7 @@ stages:
     - deployment: Test
       dependsOn: Publish
       variables:
-        PackageVersion: $[ dependencies.Publish.outputs['PublishModule.PackageVersion']]
+        PackageVersion: $[ dependencies.Publish.outputs['VersionModule.PackageVersion']]
       environment:
         name: Test
         resourceType: VirtualMachine
@@ -170,7 +172,7 @@ stages:
       condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       dependsOn: Publish
       variables:
-        PackageVersion: $[ dependencies.Publish.outputs['PublishModule.PackageVersion']]
+        PackageVersion: $[ dependencies.Publish.outputs['VersionModule.PackageVersion']]
       environment:
         name: Production
         resourceType: VirtualMachine

--- a/PSModules/stages/test-module.yml
+++ b/PSModules/stages/test-module.yml
@@ -31,9 +31,11 @@ stages:
         parameters:
           ModuleName: ${{ parameters.ModuleName }}
       - powershell: |
-          #gci "$(Build.SourcesDirectory)\Tests"
-          #get-content "$(Build.SourcesDirectory)\Tests\Help.Tests.ps1"
+          gci "$(Build.SourcesDirectory)\Tests"
+          get-content "$(Build.SourcesDirectory)\Tests\Help.Tests.ps1"
           gci -recurse "$(Build.ArtifactStagingDirectory)"
+        enabled: ${{ eq(variables['System.Debug'], 'True') }}
+        displayName: Debug Test creation
       - powershell: |
           Import-Module Pester
           Import-Module "$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}"


### PR DESCRIPTION
Remove the requirement for the explicit PAT to create the release, by using the persisted credentials from the checkout action.  This also moves the GitHub release action before the Publish-Module, because the GitHub release fails more often than Publish Module.

Also, clean up some debug statements to only print out during a debug session, and ensure the deploy-module-publish-only template matches up with changes made to the deploy-module template.