### PR TITLE
Update deploy-module.yml

### DIFF
--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -26,11 +26,11 @@ stages:
           artifactName: ${{ parameters.ModuleName }}
           targetPath: $(Build.ArtifactStagingDirectory)
       - powershell: |
-          $test = (Test-ModuleManifest -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
+          $test = (Import-PowerShellDataFile -Path '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}\*\${{ parameters.ModuleName }}.psd1')
           if ($test.PrivateData.PSData.Prerelease) {
-            $version = "$($test.version)-$($test.PrivateData.PSData.Prerelease)"
+            $version = "$($test.ModuleVersion)-$($test.PrivateData.PSData.Prerelease)"
           } else {
-            $version = $test.Version.ToString()
+            $version = $test.ModuleVersion
           }
           Write-Host "INFO [task.setvariable variable=PackageVersion;isOutput=true]$version"
           Write-Host "##vso[task.setvariable variable=PackageVersion;isOutput=true]$version"


### PR DESCRIPTION
Use Import-PowerShellDataFile instead of Test-ModuleManifest to query version, because Test-ModuleManifest will fail if dependencies aren't installed, when they aren't needed at this stage.