### PR TITLE
Trust ps repository

### DIFF
--- a/PSModules/stages/build-module.yml
+++ b/PSModules/stages/build-module.yml
@@ -15,7 +15,7 @@ stages:
             # Apparently, Install-Script isn't good enough except on Windows?
             # Install-Script Install-RequiredModule -Force -Verbose
             Save-Script Install-RequiredModule -Path '$(Pipeline.Workspace)'
-            &"$(Pipeline.Workspace)/Install-RequiredModule" -Path '$(Build.SourcesDirectory)/RequiredModules.psd1' -Confirm:$false -Verbose
+            &"$(Pipeline.Workspace)/Install-RequiredModule" -Path '$(Build.SourcesDirectory)/RequiredModules.psd1' -Confirm:$false -Verbose -TrustRegisteredRepositories
             foreach ($installErr in $IRM_InstallErrors) {
                 Write-Warning "ERROR: $installErr"
                 Write-Warning "STACKTRACE: $($installErr.ScriptStackTrace)"

--- a/PSModules/stages/test-module.yml
+++ b/PSModules/stages/test-module.yml
@@ -15,7 +15,7 @@ stages:
           # Apparently, Install-Script isn't good enough except on Windows?
           # Install-Script Install-RequiredModule -Force -Verbose
           Save-Script Install-RequiredModule -Path '$(Pipeline.Workspace)'
-          &"$(Pipeline.Workspace)/Install-RequiredModule" -Path '$(Build.SourcesDirectory)/RequiredModules.psd1' -Confirm:$false -Verbose
+          &"$(Pipeline.Workspace)/Install-RequiredModule" -Path '$(Build.SourcesDirectory)/RequiredModules.psd1' -Confirm:$false -Verbose -TrustRegisteredRepositories
           foreach ($installErr in $IRM_InstallErrors) {
               Write-Warning "ERROR: $installErr"
               Write-Warning "STACKTRACE: $($installErr.ScriptStackTrace)"


### PR DESCRIPTION
Changes to Install-RequiredModule script require adding the -TrustRegisteredRepositories flag so it will install from PSGallery, which is untrusted by default.