### PR TITLE
Enforce docspath

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,8 +22,8 @@ jobs:
 - job: build
   steps:
   - bash: |
-      echo "${{ parameters.DocsPath }}"
-      if [[ "${{ parameters.DocsPath }}" == *"DocsPath"* ]]; then exit 1; fi;
+      echo '${{ parameters.DocsPath }}'
+      if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
     displayName: Fail build if DocsPath is not set
     #condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
   # - script: |

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -23,9 +23,9 @@ jobs:
   steps:
   - bash: |
       echo "${{ parameters.DocsPath }}"
-      exit 1
+      if [[ "${{ parameters.DocsPath }}" == *"DocsPath"* ]]; then exit 1; fi;
     displayName: Fail build if DocsPath is not set
-    condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
+    #condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -26,7 +26,6 @@ jobs:
       echo '${{ parameters.DocsPath }}'
       if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
     displayName: Fail build if DocsPath is not set
-    #condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -21,6 +21,9 @@ parameters:
 jobs:
 - job: build
   steps:
+  - bash: exit 1
+    displayName: Fail build if DocsPath is not set
+    condition: contains(parameters.DocsPath, 'DocsPath')
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -23,7 +23,7 @@ jobs:
   steps:
   - bash: exit 1
     displayName: Fail build if DocsPath is not set
-    condition: contains(parameters.DocsPath, 'DocsPath')
+    condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -21,9 +21,11 @@ parameters:
 jobs:
 - job: build
   steps:
-  - bash: exit 1
+  - bash: |
+      echo "${{ parameters.DocsPath }}"
+      exit 1
     displayName: Fail build if DocsPath is not set
-    condition: contains(${{ parameters.DocsPath }}, 'DocsPath')
+    condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -23,7 +23,7 @@ jobs:
   steps:
   - bash: exit 1
     displayName: Fail build if DocsPath is not set
-    condition: ${{ contains(parameters.DocsPath, 'DocsPath') }}
+    condition: contains(${{ parameters.DocsPath }}, 'DocsPath')
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,6 +22,7 @@ jobs:
 - job: build
   steps:
   - bash: |
+      echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'
       if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
     displayName: Fail build if DocsPath is not set


### PR DESCRIPTION
By default, docspath is not set in the documentation repositories yaml file, but on the build pipeline itself.  But if it's not set, then the pipeline will deploy the docs to literally the directory `$(DocsPath)`.  This will check the value of the parameter and if it contains the string `DocsPath` it will fail, because that means setup wasn't completed properly.

This would prevent any legitimate DocsPath that contain the string `DocsPath` but that seems like a small price to pay.