### PR TITLE
Force turn on TLS1.2 when creating GitHub release

### DIFF
--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -44,7 +44,13 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
-          [Net.ServicePointManager]::SecurityProtocol
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            [Net.ServicePointManager]::SecurityProtocol
+          }
+          [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+          if ($env:SYSTEM_DEBUG -eq 'true') {
+            [Net.ServicePointManager]::SecurityProtocol
+          }
           if ($env:SYSTEM_DEBUG -eq 'true') {
             gci env:
             git --no-pager config --list

--- a/PSModules/stages/deploy-module.yml
+++ b/PSModules/stages/deploy-module.yml
@@ -44,6 +44,7 @@ stages:
           archiveFile: '$(Build.ArtifactStagingDirectory)\${{ parameters.ModuleName }}.zip'
         condition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))
       - powershell: |
+          [Net.ServicePointManager]::SecurityProtocol
           if ($env:SYSTEM_DEBUG -eq 'true') {
             gci env:
             git --no-pager config --list


### PR DESCRIPTION
Agent apparently only has `Sslv3` and `TLS` enabled by default, so this also turns on TLS1.2 in the Publish step