### PR TITLE
Linux

### DIFF
--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -11,11 +11,11 @@ parameters:
   type: string
 
 jobs:
-- deployment: ${{ parameters.Environment }}
+- deployment: ${{ parameters.Environment }}-windows
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:
-    name: ${{ parameters.Environment }}-windows
+    name: ${{ parameters.Environment }}
     resourceType: VirtualMachine
     tags: windows
   workspace:
@@ -38,11 +38,11 @@ jobs:
               TargetFolder: 'C:\inetpub\wwwroot\${{ parameters.DocsPath }}'
               CleanTargetFolder: ${{ parameters.CleanDestination }}
               OverWrite: true
-- deployment: ${{ parameters.Environment }}
+- deployment: ${{ parameters.Environment }}-linux
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:
-    name: ${{ parameters.Environment }}-linux
+    name: ${{ parameters.Environment }}
     resourceType: VirtualMachine
     tags: linux
   workspace:

--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -11,7 +11,7 @@ parameters:
   type: string
 
 jobs:
-- deployment: ${{ parameters.Environment }}-windows
+- deployment: ${{ parameters.Environment }}_windows
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:
@@ -38,7 +38,7 @@ jobs:
               TargetFolder: 'C:\inetpub\wwwroot\${{ parameters.DocsPath }}'
               CleanTargetFolder: ${{ parameters.CleanDestination }}
               OverWrite: true
-- deployment: ${{ parameters.Environment }}-linux
+- deployment: ${{ parameters.Environment }}_linux
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:

--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -17,6 +17,7 @@ jobs:
   environment:
     name: ${{ parameters.Environment }}
     resourceType: VirtualMachine
+    tags: windows
   workspace:
     clean: all
   strategy:

--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -38,3 +38,30 @@ jobs:
               TargetFolder: 'C:\inetpub\wwwroot\${{ parameters.DocsPath }}'
               CleanTargetFolder: ${{ parameters.CleanDestination }}
               OverWrite: true
+- deployment: ${{ parameters.Environment }}
+  condition: ${{ parameters.BuildCondition }}
+  dependsOn: build
+  environment:
+    name: ${{ parameters.Environment }}
+    resourceType: VirtualMachine
+    tags: linux
+  workspace:
+    clean: all
+  strategy:
+    rolling:
+      deploy:
+        steps:
+          #- ${{ if eq(parameters.CleanDestination, true) }}:
+          - task: DeleteFiles@1
+            inputs:
+              SourceFolder: $(Pipeline.Workspace)
+              Contents: ${{ parameters.ArtifactName }}
+          - download: current
+            artifact: ${{ parameters.ArtifactName }}
+          - task: CopyFiles@2
+            inputs:
+              SourceFolder: '$(Pipeline.Workspace)/${{ parameters.ArtifactName }}'
+              Contents: '**'
+              TargetFolder: 'C:\inetpub\wwwroot\${{ parameters.DocsPath }}'
+              CleanTargetFolder: ${{ parameters.CleanDestination }}
+              OverWrite: true

--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -62,6 +62,6 @@ jobs:
             inputs:
               SourceFolder: '$(Pipeline.Workspace)/${{ parameters.ArtifactName }}'
               Contents: '**'
-              TargetFolder: 'C:\inetpub\wwwroot\${{ parameters.DocsPath }}'
+              TargetFolder: '/var/www/html/${{ parameters.DocsPath }}'
               CleanTargetFolder: ${{ parameters.CleanDestination }}
               OverWrite: true

--- a/mkdocs/deploy-docs.yml
+++ b/mkdocs/deploy-docs.yml
@@ -15,7 +15,7 @@ jobs:
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:
-    name: ${{ parameters.Environment }}
+    name: ${{ parameters.Environment }}-windows
     resourceType: VirtualMachine
     tags: windows
   workspace:
@@ -42,7 +42,7 @@ jobs:
   condition: ${{ parameters.BuildCondition }}
   dependsOn: build
   environment:
-    name: ${{ parameters.Environment }}
+    name: ${{ parameters.Environment }}-linux
     resourceType: VirtualMachine
     tags: linux
   workspace:


### PR DESCRIPTION
Add support for both Linux and Windows Hosts.

Carrying on assumptions, the deploy has always assumed the deploy on a windows machine is to `C:\inetpub\wwwroot\`.  Now it will also assume a linux path of `/var/www/html/`.  Machines live in the same environment, and this time use a tag `windows` or `linux` to determine which jobs will run.  Machines with a tag `windows` will deploy to `C:\inetpub\wwwroot\` and machines with a tag `linux` will deploy to `/var/www/html/`