### PR TITLE
Use python directly instead of container

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,7 +46,7 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      echo -e "FROM squidfunk/mkdocs-material \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
+      echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
       docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,8 +46,10 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
-      docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
+      pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      mkdocs build -d $(Build.ArtifactStagingDirectory)
+      # echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
+      # docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -48,8 +48,6 @@ jobs:
   - script: |
       pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
-      # echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
-      # docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,7 +46,7 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
+      echo -e "FROM squidfunk/mkdocs-material:8.2.10 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
       docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,7 +46,7 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      echo -e "FROM squidfunk/mkdocs-material:8.2.10 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
+      echo -e "FROM squidfunk/mkdocs-material:8.2.9 \n RUN pip install mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin mkdocs-mermaid2-plugin" | docker build -t squidfunk/mkdocs-material -
       docker run --rm -v ${PWD}:/docs -v $(Build.ArtifactStagingDirectory):/docs/site squidfunk/mkdocs-material build
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
The container isn't as fast or slick since we've added plugins, and the latest version of the container fails bizarrely in Azure DevOps.  Using python running directly on the agent works just as well, and is in fact a little faster.  This also removes the mermaid plugin.