### PR TITLE
Use Build Definition Name for path to docs

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -42,20 +42,20 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    - bash: |
-        echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ variables['Build.DefinitionName'] }}"
-        echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
-  - ${{ else }}:
-    - bash: |
-        echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ parameters.DocsPath }}"
-        echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
-  - bash: |
-      echo '$(templateDocsPath)'
-      echo '$(templateArtifactName)'
-      # echo '${{ parameters.DocsPath }}'
-      # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-    displayName: Fail build if DocsPath is not set
+  # - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+  #   - bash: |
+  #       echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true;isoutput=true]${{ variables['Build.DefinitionName'] }}"
+  #       echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true;isoutput=true]${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+  # - ${{ else }}:
+  #   - bash: |
+  #       echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true;isoutput=true]${{ parameters.DocsPath }}"
+  #       echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true;isoutput=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+  # - bash: |
+  #     echo '$(templateDocsPath)'
+  #     echo '$(templateArtifactName)'
+  #     # echo '${{ parameters.DocsPath }}'
+  #     # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+  #   displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"
@@ -83,22 +83,38 @@ jobs:
     artifact: $(templateArtifactName)
 - template: deploy-docs.yml
   parameters:
-    DocsPath: $(templateDocsPath)
+    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+      DocsPath: ${{ variables['Build.DefinitionName'] }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+    ${{ else }}:
+      DocsPath: ${{ parameters.DocsPath }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: $(templateArtifactName)
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: $(templateDocsPath)
+    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+      DocsPath: ${{ variables['Build.DefinitionName'] }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+    ${{ else }}:
+      DocsPath: ${{ parameters.DocsPath }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+    # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: $(templateArtifactName)
+    # ArtifactName: $(templateArtifactName)
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: $(templateDocsPath)
+    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+      DocsPath: ${{ variables['Build.DefinitionName'] }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+    ${{ else }}:
+      DocsPath: ${{ parameters.DocsPath }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+    # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: $(templateArtifactName)
+    # ArtifactName: $(templateArtifactName)
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -20,19 +20,23 @@ parameters:
 
 variables:
   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-  - name: templateDocsPath
-    value: ${{ variables['Build.DefinitionName'] }}
-    readonly: true
-  - name: templateArtifactName
-    value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    readonly: true
+    templateDocsPath: ${{ variables['Build.DefinitionName'] }}
+  # - name: templateDocsPath
+  #   value: ${{ variables['Build.DefinitionName'] }}
+  #   readonly: true
+    templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+  # - name: templateArtifactName
+  #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+  #   readonly: true
   ${{ else }}:
-  - name: templateDocsPath
-    value: ${{ parameters.DocsPath }}
-    readonly: true
-  - name: templateArtifactName
-    value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-    readonly: true
+    templateDocsPath: ${{ parameters.DocsPath }}
+  # - name: templateDocsPath
+  #   value: ${{ parameters.DocsPath }}
+  #   readonly: true
+    templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+  # - name: templateArtifactName
+  #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+  #   readonly: true
 
 
 jobs:

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -18,15 +18,35 @@ parameters:
   type: boolean
   default: false
 
+variables:
+  ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    - name: templateDocsPath
+      value: ${{ variables['Build.DefinitionName'] }}
+      readonly: true
+    - name: templateArtifactName
+      value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+      readonly: true
+  ${{ else }}:
+    - name: templateDocsPath
+      value: ${{ parameters.DocsPath }}
+      readonly: true
+    - name: templateArtifactName
+      value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+      readonly: true
+
+
 jobs:
 - job: build
   steps:
-  - bash: |
-      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
-      echo '$(Build.DefinitionName)'
-      echo '${{ parameters.DocsPath }}'
-      if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-    displayName: Fail build if DocsPath is not set
+  # - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+  #   -bash: |
+  #     echo '${{ variables['Build.DefinitionName'] }}'
+  # - bash: |
+  #     echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
+  #     echo '$(Build.DefinitionName)'
+  #     echo '${{ parameters.DocsPath }}'
+  #     if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+  #   displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"
@@ -51,25 +71,25 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    artifact: ${{ variables.ArtifactName }}
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ parameters.DocsPath }}
+    DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    ArtifactName: ${{ variables.ArtifactName }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ parameters.DocsPath }}
+    DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    ArtifactName: ${{ variables.ArtifactName }}
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ parameters.DocsPath }}
+    DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    ArtifactName: ${{ variables.ArtifactName }}
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -19,7 +19,6 @@ parameters:
   type: boolean
   default: false
 
-
 jobs:
 - job: build
   steps:
@@ -46,21 +45,21 @@ jobs:
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables['Build.DefinitionName'] }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables['Build.DefinitionName'] }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables['Build.DefinitionName'] }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -43,31 +43,31 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
-    - bash: |
-        echo "True"
-        echo '${{ parameters.DocsPath }}'
-        echo '$(DocsPath'
-        echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
-        echo '${{ contains('lpt-public', '$(DocsPath') }}'
-        echo '${{ contains('ABCDE', 'BCD') }}'
-        echo '${{ contains('ABCDE', 'ACE') }}'
-        echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
-        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
-  - ${{ else }}:
-    - bash: |
-        echo "Else"
-        echo '${{ parameters.DocsPath }}'
-        echo 'DocsPath'
-        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
-        echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
-        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
-  - bash: |
-      echo '$(Build.DefinitionName)'
-      echo '${{ parameters.DocsPath }}'
-      echo '${{ parameters.ArtifactName }}'
-      # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-    displayName: Fail build if DocsPath is not set
+  # - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
+  #   - bash: |
+  #       echo "True"
+  #       echo '${{ parameters.DocsPath }}'
+  #       echo '$(DocsPath'
+  #       echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
+  #       echo '${{ contains('lpt-public', '$(DocsPath') }}'
+  #       echo '${{ contains('ABCDE', 'BCD') }}'
+  #       echo '${{ contains('ABCDE', 'ACE') }}'
+  #       echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
+  #       echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+  # - ${{ else }}:
+  #   - bash: |
+  #       echo "Else"
+  #       echo '${{ parameters.DocsPath }}'
+  #       echo 'DocsPath'
+  #       echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
+  #       echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
+  #       echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
+  # - bash: |
+  #     echo '$(Build.DefinitionName)'
+  #     echo '${{ parameters.DocsPath }}'
+  #     echo '${{ parameters.ArtifactName }}'
+  #     # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+  #   displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"
@@ -92,44 +92,47 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-      artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    ${{ else }}:
-      artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    #   artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    # ${{ else }}:
+    #   artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml
   parameters:
-    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-      DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    ${{ else }}:
-      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    # ${{ else }}:
+    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    DocsPath: ${{ variables['Build.DefinitionName'] }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
-    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-      DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    ${{ else }}:
-      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
-    # DocsPath: $(templateDocsPath)
+    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    # ${{ else }}:
+    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    DocsPath: ${{ variables['Build.DefinitionName'] }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    # ArtifactName: $(templateArtifactName)
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
-    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-      DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    ${{ else }}:
-      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
-    # DocsPath: $(templateDocsPath)
+    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    # ${{ else }}:
+    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
+    DocsPath: ${{ variables['Build.DefinitionName'] }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    # ArtifactName: $(templateArtifactName)
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -19,60 +19,10 @@ parameters:
   type: boolean
   default: false
 
-# variables:
-#   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-#     templateDocsPath: ${{ variables['Build.DefinitionName'] }}
-#   # - name: templateDocsPath
-#   #   value: ${{ variables['Build.DefinitionName'] }}
-#   #   readonly: true
-#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-#   # - name: templateArtifactName
-#   #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-#   #   readonly: true
-#   ${{ else }}:
-#     templateDocsPath: ${{ parameters.DocsPath }}
-#   # - name: templateDocsPath
-#   #   value: ${{ parameters.DocsPath }}
-#   #   readonly: true
-#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-#   # - name: templateArtifactName
-#   #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-#   #   readonly: true
-
 
 jobs:
 - job: build
   steps:
-  # - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
-  #   - bash: |
-  #       echo "True"
-  #       echo '${{ parameters.DocsPath }}'
-  #       echo '$(DocsPath'
-  #       echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
-  #       echo '${{ contains('lpt-public', '$(DocsPath') }}'
-  #       echo '${{ contains('ABCDE', 'BCD') }}'
-  #       echo '${{ contains('ABCDE', 'ACE') }}'
-  #       echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
-  #       echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
-  # - ${{ else }}:
-  #   - bash: |
-  #       echo "Else"
-  #       echo '${{ parameters.DocsPath }}'
-  #       echo 'DocsPath'
-  #       echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
-  #       echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
-  #       echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
-  # - bash: |
-  #     echo '$(Build.DefinitionName)'
-  #     echo '${{ parameters.DocsPath }}'
-  #     echo '${{ parameters.ArtifactName }}'
-  #     # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-  #   displayName: Fail build if DocsPath is not set
-  # - script: |
-  #     sudo npm i -g markdownlint-cli
-  #     markdownlint "**/*.md"
-  #   continueOnError: true
-  #   displayName: Run Markdownlint
   - script: |
       git clone https://github.com/FISHMANPET/markdownlint-cli.git --single-branch --branch junit "$(Agent.BuildDirectory)/markdownlint-cli"
       pushd "$(Agent.BuildDirectory)/markdownlint-cli"
@@ -90,21 +40,13 @@ jobs:
   - script: |
       pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
+      echo '$(Build.ArtifactStagingDirectory)'
+      cp .htaccess $(Build.ArtifactStagingDirectory)/
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    #   artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    # ${{ else }}:
-    #   artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml
   parameters:
-    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    # ${{ else }}:
-    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     DocsPath: ${{ variables['Build.DefinitionName'] }}
     ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
@@ -112,12 +54,6 @@ jobs:
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
-    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    # ${{ else }}:
-    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     DocsPath: ${{ variables['Build.DefinitionName'] }}
     ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
@@ -125,12 +61,6 @@ jobs:
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
-    # ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    #   DocsPath: ${{ variables['Build.DefinitionName'] }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    # ${{ else }}:
-    #   DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
-    #   ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     DocsPath: ${{ variables['Build.DefinitionName'] }}
     ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -51,12 +51,12 @@ jobs:
   #   - bash: |
   #       echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true;isoutput=true]${{ parameters.DocsPath }}"
   #       echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true;isoutput=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
-  # - bash: |
-  #     echo '$(templateDocsPath)'
-  #     echo '$(templateArtifactName)'
-  #     # echo '${{ parameters.DocsPath }}'
-  #     # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-  #   displayName: Fail build if DocsPath is not set
+  - bash: |
+      echo '$(Build.DefinitionName)'
+      echo '${{ parameters.DocsPath }}'
+      echo '${{ parameters.ArtifactName }}'
+      # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+    displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -43,6 +43,8 @@ parameters:
 jobs:
 - job: build
   steps:
+  - powershell: |
+      gci env:
   - ${{ if contains(variables['DocsPath'], '$(DocsPath') }}:
     - bash: |
         echo "True"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,7 +22,7 @@ jobs:
 - job: build
   steps:
   - bash: |
-      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName'], 'string literal') }}'
+      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'
       if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
@@ -51,25 +51,25 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+    artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ parameters.DocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ parameters.DocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ parameters.DocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+    ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -18,27 +18,6 @@ parameters:
   type: boolean
   default: false
 
-# variables:
-#   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-#     templateDocsPath: ${{ variables['Build.DefinitionName'] }}
-#   # - name: templateDocsPath
-#   #   value: ${{ variables['Build.DefinitionName'] }}
-#   #   readonly: true
-#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-#   # - name: templateArtifactName
-#   #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-#   #   readonly: true
-#   ${{ else }}:
-#     templateDocsPath: ${{ parameters.DocsPath }}
-#   # - name: templateDocsPath
-#   #   value: ${{ parameters.DocsPath }}
-#   #   readonly: true
-#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-#   # - name: templateArtifactName
-#   #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-#   #   readonly: true
-
-
 jobs:
 - job: build
   steps:

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -50,12 +50,12 @@ jobs:
     - bash: |
         echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ parameters.DocsPath }}"
         echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
-  # - bash: |
-  #     echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
-  #     echo '$(Build.DefinitionName)'
-  #     echo '${{ parameters.DocsPath }}'
-  #     if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-  #   displayName: Fail build if DocsPath is not set
+  - bash: |
+      echo '$(templateDocsPath)'
+      echo '$(templateArtifactName)'
+      # echo '${{ parameters.DocsPath }}'
+      # if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+    displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -41,12 +41,6 @@ jobs:
       pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
-  - bash: |
-      FILE=.htaccess
-      if test -f "$FILE"; then
-        cp $FILE $(Build.ArtifactStagingDirectory)/
-      fi
-    displayName: copy htaccess
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,13 +46,13 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.testparam, 'testparam') }}:
+  - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
     - bash: |
         echo "True"
-        echo '${{ parameters.testparam }}'
-        echo 'DocsPath'
-        echo '${{ contains(parameters.testparam, 'DocsPath') }}'
-        echo '${{ contains('lpt-public', 'DocsPath') }}'
+        echo '${{ parameters.DocsPath }}'
+        echo '$(DocsPath'
+        echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
+        echo '${{ contains('lpt-public', '$(DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'
         echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -43,14 +43,16 @@ parameters:
 jobs:
 - job: build
   steps:
-  # - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-  #   - bash: |
-  #       echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true;isoutput=true]${{ variables['Build.DefinitionName'] }}"
-  #       echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true;isoutput=true]${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
-  # - ${{ else }}:
-  #   - bash: |
-  #       echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true;isoutput=true]${{ parameters.DocsPath }}"
-  #       echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true;isoutput=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+  - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    - bash: |
+        echo "True"
+        echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
+        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+  - ${{ else }}:
+    - bash: |
+        echo "Else"
+        echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
+        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
   - bash: |
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -40,9 +40,13 @@ jobs:
   - script: |
       pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
-      echo '$(Build.ArtifactStagingDirectory)'
-      cp .htaccess $(Build.ArtifactStagingDirectory)/
     displayName: mkdocs-material build
+  - bash: |
+      FILE=.htaccess
+      if test -f "$FILE"; then
+        cp $FILE $(Build.ArtifactStagingDirectory)/
+      fi
+    displayName: copy htaccess
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -43,12 +43,12 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+  - ${{ if contains(parameters.docspath, 'DocsPath') }}:
     - bash: |
         echo "True"
         echo '${{ parameters.DocsPath }}'
         echo 'DocsPath'
-        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
+        echo '${{ contains(parameters.docspath, 'DocsPath') }}'
         echo '${{ contains('lpt-public', 'DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -2,6 +2,7 @@
 parameters:
 - name: DocsPath
   type: string
+  default: ''
 - name: CleanDestination
   type: boolean
   default: true
@@ -80,15 +81,18 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: $(templateArtifactName)
+    ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+      artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    ${{ else }}:
+      artifact: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml
   parameters:
     ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
       ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     CleanDestination: ${{ parameters.CleanDestination }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
@@ -98,8 +102,8 @@ jobs:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
       ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
     # ArtifactName: $(templateArtifactName)
@@ -111,8 +115,8 @@ jobs:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
       ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+      DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}
     # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
     # ArtifactName: $(templateArtifactName)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,7 +46,7 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.testparam, 'DocsPath') }}:
+  - ${{ if contains(parameters.testparam, 'testparam') }}:
     - bash: |
         echo "True"
         echo '${{ parameters.testparam }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -3,9 +3,6 @@ parameters:
 - name: DocsPath
   type: string
   default: ''
-- name: testparam
-  type: string
-  default: ''
 - name: CleanDestination
   type: boolean
   default: true
@@ -46,12 +43,12 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(variables.DocsPath, '$(DocsPath') }}:
+  - ${{ if contains(variables['DocsPath'], '$(DocsPath') }}:
     - bash: |
         echo "True"
-        echo '${{ variables.DocsPath }}'
+        echo '${{ variables['DocsPath'] }}'
         echo '$(DocsPath'
-        echo '${{ contains(variables.DocsPath, '$(DocsPath') }}'
+        echo '${{ contains(variables['DocsPath'], '$(DocsPath') }}'
         echo '${{ contains('lpt-public', '$(DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'
@@ -60,11 +57,11 @@ jobs:
   - ${{ else }}:
     - bash: |
         echo "Else"
-        echo '${{ variables.DocsPath }}'
+        echo '${{ variables['DocsPath'] }}'
         echo 'DocsPath'
-        echo '${{ contains(variables.DocsPath, 'DocsPath') }}'
-        echo "DocsPath: ${{ coalesce(variables.DocsPath, variables['Build.DefinitionName']) }}"
-        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables.DocsPath, variables['Build.DefinitionName']) }}"
+        echo '${{ contains(variables['DocsPath']h, 'DocsPath') }}'
+        echo "DocsPath: ${{ coalesce(variables['DocsPath'], variables['Build.DefinitionName']) }}"
+        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['DocsPath'], variables['Build.DefinitionName']) }}"
   - bash: |
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -18,6 +18,27 @@ parameters:
   type: boolean
   default: false
 
+# variables:
+#   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+#     templateDocsPath: ${{ variables['Build.DefinitionName'] }}
+#   # - name: templateDocsPath
+#   #   value: ${{ variables['Build.DefinitionName'] }}
+#   #   readonly: true
+#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+#   # - name: templateArtifactName
+#   #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+#   #   readonly: true
+#   ${{ else }}:
+#     templateDocsPath: ${{ parameters.DocsPath }}
+#   # - name: templateDocsPath
+#   #   value: ${{ parameters.DocsPath }}
+#   #   readonly: true
+#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+#   # - name: templateArtifactName
+#   #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+#   #   readonly: true
+
+
 jobs:
 - job: build
   steps:
@@ -59,25 +80,25 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: ${{ variables.ArtifactName }}
+    artifact: ${{ variables.templateArtifactName }}
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.ArtifactName }}
+    ArtifactName: ${{ variables.templateArtifactName }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.ArtifactName }}
+    ArtifactName: ${{ variables.templateArtifactName }}
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables.templateDocsPath }}
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.ArtifactName }}
+    ArtifactName: ${{ variables.templateArtifactName }}
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -43,14 +43,12 @@ parameters:
 jobs:
 - job: build
   steps:
-  - powershell: |
-      gci env:
-  - ${{ if contains(variables['DocsPath'], '$(DocsPath') }}:
+  - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
     - bash: |
         echo "True"
-        echo '${{ variables['DocsPath'] }}'
+        echo '${{ parameters.DocsPath }}'
         echo '$(DocsPath'
-        echo '${{ contains(variables['DocsPath'], '$(DocsPath') }}'
+        echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
         echo '${{ contains('lpt-public', '$(DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'
@@ -59,11 +57,11 @@ jobs:
   - ${{ else }}:
     - bash: |
         echo "Else"
-        echo '${{ variables['DocsPath'] }}'
+        echo '${{ parameters.DocsPath }}'
         echo 'DocsPath'
-        echo '${{ contains(variables['DocsPath'], 'DocsPath') }}'
-        echo "DocsPath: ${{ coalesce(variables['DocsPath'], variables['Build.DefinitionName']) }}"
-        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['DocsPath'], variables['Build.DefinitionName']) }}"
+        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
+        echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
+        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
   - bash: |
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -61,7 +61,7 @@ jobs:
         echo "Else"
         echo '${{ variables['DocsPath'] }}'
         echo 'DocsPath'
-        echo '${{ contains(variables['DocsPath']h, 'DocsPath') }}'
+        echo '${{ contains(variables['DocsPath'], 'DocsPath') }}'
         echo "DocsPath: ${{ coalesce(variables['DocsPath'], variables['Build.DefinitionName']) }}"
         echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['DocsPath'], variables['Build.DefinitionName']) }}"
   - bash: |

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -18,39 +18,44 @@ parameters:
   type: boolean
   default: false
 
-variables:
-  ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    templateDocsPath: ${{ variables['Build.DefinitionName'] }}
-  # - name: templateDocsPath
-  #   value: ${{ variables['Build.DefinitionName'] }}
-  #   readonly: true
-    templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-  # - name: templateArtifactName
-  #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-  #   readonly: true
-  ${{ else }}:
-    templateDocsPath: ${{ parameters.DocsPath }}
-  # - name: templateDocsPath
-  #   value: ${{ parameters.DocsPath }}
-  #   readonly: true
-    templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-  # - name: templateArtifactName
-  #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-  #   readonly: true
+# variables:
+#   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+#     templateDocsPath: ${{ variables['Build.DefinitionName'] }}
+#   # - name: templateDocsPath
+#   #   value: ${{ variables['Build.DefinitionName'] }}
+#   #   readonly: true
+#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+#   # - name: templateArtifactName
+#   #   value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+#   #   readonly: true
+#   ${{ else }}:
+#     templateDocsPath: ${{ parameters.DocsPath }}
+#   # - name: templateDocsPath
+#   #   value: ${{ parameters.DocsPath }}
+#   #   readonly: true
+#     templateArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+#   # - name: templateArtifactName
+#   #   value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+#   #   readonly: true
 
 
 jobs:
 - job: build
   steps:
-  # - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-  #   -bash: |
-  #     echo '${{ variables['Build.DefinitionName'] }}'
-  # - bash: |
-  #     echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
-  #     echo '$(Build.DefinitionName)'
-  #     echo '${{ parameters.DocsPath }}'
-  #     if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-  #   displayName: Fail build if DocsPath is not set
+  - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
+    - bash: |
+        echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ variables['Build.DefinitionName'] }}"
+        echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+  - ${{ else }}:
+    - bash: |
+        echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ parameters.DocsPath }}"
+        echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+  - bash: |
+      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
+      echo '$(Build.DefinitionName)'
+      echo '${{ parameters.DocsPath }}'
+      if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+    displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,6 +22,7 @@ jobs:
 - job: build
   steps:
   - bash: |
+      echo '${{ coalesce(variables.DocsPath, variables.Build.DefinitionName) }}'
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'
       if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,12 +46,12 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.DocsPath, '$(DocsPath') }}:
+  - ${{ if contains(variables.DocsPath, '$(DocsPath') }}:
     - bash: |
         echo "True"
-        echo '${{ parameters.DocsPath }}'
+        echo '${{ variables.DocsPath }}'
         echo '$(DocsPath'
-        echo '${{ contains(parameters.docspath, '$(DocsPath') }}'
+        echo '${{ contains(variables.DocsPath, '$(DocsPath') }}'
         echo '${{ contains('lpt-public', '$(DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'
@@ -60,11 +60,11 @@ jobs:
   - ${{ else }}:
     - bash: |
         echo "Else"
-        echo '${{ parameters.DocsPath }}'
+        echo '${{ variables.DocsPath }}'
         echo 'DocsPath'
-        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
-        echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
-        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
+        echo '${{ contains(variables.DocsPath, 'DocsPath') }}'
+        echo "DocsPath: ${{ coalesce(variables.DocsPath, variables['Build.DefinitionName']) }}"
+        echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables.DocsPath, variables['Build.DefinitionName']) }}"
   - bash: |
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -20,19 +20,19 @@ parameters:
 
 variables:
   ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
-    - name: templateDocsPath
-      value: ${{ variables['Build.DefinitionName'] }}
-      readonly: true
-    - name: templateArtifactName
-      value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-      readonly: true
+  - name: templateDocsPath
+    value: ${{ variables['Build.DefinitionName'] }}
+    readonly: true
+  - name: templateArtifactName
+    value: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+    readonly: true
   ${{ else }}:
-    - name: templateDocsPath
-      value: ${{ parameters.DocsPath }}
-      readonly: true
-    - name: templateArtifactName
-      value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
-      readonly: true
+  - name: templateDocsPath
+    value: ${{ parameters.DocsPath }}
+    readonly: true
+  - name: templateArtifactName
+    value: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
+    readonly: true
 
 
 jobs:

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -46,11 +46,17 @@ jobs:
   - ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
     - bash: |
         echo "True"
+        echo '${{ parameters.DocsPath }}'
+        echo 'DocsPath'
+        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
         echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
         echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
   - ${{ else }}:
     - bash: |
         echo "Else"
+        echo '${{ parameters.DocsPath }}'
+        echo 'DocsPath'
+        echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
         echo "DocsPath: ${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}"
         echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath, variables['Build.DefinitionName']) }}"
   - bash: |

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -3,6 +3,9 @@ parameters:
 - name: DocsPath
   type: string
   default: ''
+- name: testparam
+  type: string
+  default: ''
 - name: CleanDestination
   type: boolean
   default: true
@@ -43,12 +46,12 @@ parameters:
 jobs:
 - job: build
   steps:
-  - ${{ if contains(parameters.docspath, 'DocsPath') }}:
+  - ${{ if contains(parameters.testparam, 'DocsPath') }}:
     - bash: |
         echo "True"
-        echo '${{ parameters.DocsPath }}'
+        echo '${{ parameters.testparam }}'
         echo 'DocsPath'
-        echo '${{ contains(parameters.docspath, 'DocsPath') }}'
+        echo '${{ contains(parameters.testparam, 'DocsPath') }}'
         echo '${{ contains('lpt-public', 'DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,6 +22,11 @@ parameters:
 jobs:
 - job: build
   steps:
+  # - script: |
+  #     sudo npm i -g markdownlint-cli
+  #     markdownlint "**/*.md"
+  #   continueOnError: true
+  #   displayName: Run Markdownlint
   - script: |
       git clone https://github.com/FISHMANPET/markdownlint-cli.git --single-branch --branch junit "$(Agent.BuildDirectory)/markdownlint-cli"
       pushd "$(Agent.BuildDirectory)/markdownlint-cli"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -85,10 +85,10 @@ jobs:
   parameters:
     ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}"
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+      DocsPath: ${{ parameters.DocsPath }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
     CleanDestination: ${{ parameters.CleanDestination }}
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
@@ -96,10 +96,10 @@ jobs:
   parameters:
     ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}"
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+      DocsPath: ${{ parameters.DocsPath }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
     # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
     # ArtifactName: $(templateArtifactName)
@@ -109,10 +109,10 @@ jobs:
   parameters:
     ${{ if contains(parameters.DocsPath, 'DocsPath') }}:
       DocsPath: ${{ variables['Build.DefinitionName'] }}
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
     ${{ else }}:
-      DocsPath: ${{ parameters.DocsPath }}"
-      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
+      DocsPath: ${{ parameters.DocsPath }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}
     # DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
     # ArtifactName: $(templateArtifactName)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,7 +22,7 @@ jobs:
 - job: build
   steps:
   - bash: |
-      echo '${{ coalesce(variables.DocsPath, variables.Build.DefinitionName) }}'
+      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName'], 'string literal') }}'
       echo '$(Build.DefinitionName)'
       echo '${{ parameters.DocsPath }}'
       if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -50,12 +50,12 @@ jobs:
     - bash: |
         echo "##vso[task.setvariable variable=templateDocsPath;isreadonly=true]${{ parameters.DocsPath }}"
         echo "##vso[task.setvariable variable=templateArtifactName;isreadonly=true]${{ coalesce(parameters.ArtifactName, parameters.DocsPath) }}"
-  - bash: |
-      echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
-      echo '$(Build.DefinitionName)'
-      echo '${{ parameters.DocsPath }}'
-      if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
-    displayName: Fail build if DocsPath is not set
+  # - bash: |
+  #     echo '${{ coalesce(parameters.DocsPath, variables['Build.DefinitionName']) }}'
+  #     echo '$(Build.DefinitionName)'
+  #     echo '${{ parameters.DocsPath }}'
+  #     if [[ '${{ parameters.DocsPath }}' == *"DocsPath"* ]]; then exit 1; fi;
+  #   displayName: Fail build if DocsPath is not set
   # - script: |
   #     sudo npm i -g markdownlint-cli
   #     markdownlint "**/*.md"
@@ -80,25 +80,25 @@ jobs:
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: ${{ variables.templateArtifactName }}
+    artifact: $(templateArtifactName)
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ variables.templateDocsPath }}
+    DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.templateArtifactName }}
+    ArtifactName: $(templateArtifactName)
     Environment: Dev
     BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ variables.templateDocsPath }}
+    DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.templateArtifactName }}
+    ArtifactName: $(templateArtifactName)
     Environment: Tst
     BuildCondition: or(and(succeeded(), not(startsWith(variables['build.sourceBranchName'], 'dev')), eq(${{ parameters.DevDeploys }}, true)), and(succeeded(), eq(${{ parameters.DevDeploys }}, false)))
 - template: deploy-docs.yml
   parameters:
-    DocsPath: ${{ variables.templateDocsPath }}
+    DocsPath: $(templateDocsPath)
     CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ variables.templateArtifactName }}
+    ArtifactName: $(templateArtifactName)
     Environment: Prd
     BuildCondition: and(succeeded(), eq(variables['build.sourceBranchName'], '${{ parameters.DefaultBranch }}'))

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -49,6 +49,7 @@ jobs:
         echo '${{ parameters.DocsPath }}'
         echo 'DocsPath'
         echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
+        echo '${{ contains('lpt-public', 'DocsPath') }}'
         echo '${{ contains('ABCDE', 'BCD') }}'
         echo '${{ contains('ABCDE', 'ACE') }}'
         echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -49,6 +49,8 @@ jobs:
         echo '${{ parameters.DocsPath }}'
         echo 'DocsPath'
         echo '${{ contains(parameters.DocsPath, 'DocsPath') }}'
+        echo '${{ contains('ABCDE', 'BCD') }}'
+        echo '${{ contains('ABCDE', 'ACE') }}'
         echo "DocsPath: ${{ variables['Build.DefinitionName'] }}"
         echo "ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}"
   - ${{ else }}:


### PR DESCRIPTION
Because the DocsPath variable can be set by the template consumer, it is possible for one pipeline to overwrite (inadvertently or maliciously) another site.  This reads the path for the site from the definition name instead, which can't be changed by consumers of the service.

This will "break" existing pipelines that haven't been renamed, by deploying the docs to the "wrong" path, until the name of the pipeline is renamed.