### PR TITLE
Generate htaccess file based on settings passed to parameter

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -98,13 +98,18 @@ jobs:
                 $output = "OIDCUnAuthAction pass"
             }
             default {
-                $aadGroup = Get-AzADGroup -DisplayName $auth
+                $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
+                if -not $aadGroup {
+                    throw "Group not found"
+                }
                 $servicePrincipalId = 'd23effd1-8b94-4b9c-85fb-a0a799d7ae50'
                 $assignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $servicePrincipalId
                 if ($aadGroup.Id -in $assignments.principalId) {
                     $output = "Require claim `"groups~$($aadGroup.Id)`""
                 }
-                throw "Group not Valid"
+                else {
+                    throw "Group not Valid"
+                }
             }
         }
         Write-Host $output

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -98,6 +98,7 @@ jobs:
                 Connect-MgGraph -AccessToken $graphToken
                 $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
                 if (-not $aadGroup) {
+                    Write-Host "##vso[task.logissue type=error]The group $auth could not be found, verify you have specified the correct group name in your azure-pipelines.yml file."
                     throw "Group not found"
                 }
                 $servicePrincipalId = 'd23effd1-8b94-4b9c-85fb-a0a799d7ae50'
@@ -106,6 +107,7 @@ jobs:
                     $output = "Require claim `"groups~$($aadGroup.Id)`""
                 }
                 else {
+                    Write-Host "##vso[task.logissue type=error]The group $auth is not registered for this application, verify you have specified the correct group name in your azure-pipelines.yml file, and verify with SRE that they have registered the group correctly."
                     throw "Group not Valid"
                 }
             }

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -99,7 +99,7 @@ jobs:
             }
             default {
                 $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
-                if -not $aadGroup {
+                if (-not $aadGroup) {
                     throw "Group not found"
                 }
                 $servicePrincipalId = 'd23effd1-8b94-4b9c-85fb-a0a799d7ae50'

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -45,6 +45,12 @@ jobs:
       pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
+  - bash: |
+      FILE=.htaccess
+      if test -f "$FILE"; then
+        cp $FILE $(Build.ArtifactStagingDirectory)/
+      fi
+    displayName: copy htaccess
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -87,7 +87,7 @@ jobs:
         $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
         Connect-MgGraph -AccessToken $graphToken
 
-        $auth = ${{ parameters.AuthSetting }}
+        $auth = "${{ parameters.AuthSetting }}"
         # $auth = "valid-user"
 
         switch ($auth) {

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -84,8 +84,9 @@ jobs:
       ScriptType: 'InlineScript'
       Inline: |
         $context = Get-AzContext
-        $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
-        Connect-MgGraph -AccessToken $graphToken
+        $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com")
+        write-host $graphToken
+        Connect-MgGraph -AccessToken $graphToken.AccessToken
 
         $auth = "${{ parameters.AuthSetting }}"
         # $auth = "valid-user"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -24,6 +24,9 @@ parameters:
   values:
   - mkdocs
   - hugo
+- name: AuthSetting
+  type: string
+  default: valid-user
 
 jobs:
 - job: build
@@ -75,12 +78,46 @@ jobs:
     - template: build-mkdocs.yml
   - ${{ elseif eq(parameters.BuildEngine, 'hugo') }}:
     - template: build-hugo.yml
-  - bash: |
-      FILE=.htaccess
-      if test -f "$FILE"; then
-        cp $FILE $(Build.ArtifactStagingDirectory)/
-      fi
-    displayName: copy htaccess
+  - task: AzurePowerShell@5
+    inputs:
+      azureSubscription: 'docs-publish'
+      ScriptType: 'InlineScript'
+      Inline: |
+        $context = Get-AzContext
+        $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
+        Connect-MgGraph -AccessToken $graphToken
+
+        $auth = ${{ parameters.AuthSetting }}
+        # $auth = "valid-user"
+
+        switch ($auth) {
+            "valid-user" {
+                $output = "Require valid-user"
+            }
+            "pass" {
+                $output = "OIDCUnAuthAction pass"
+            }
+            default {
+                $aadGroup = Get-AzADGroup -DisplayName $auth
+                $servicePrincipalId = 'd23effd1-8b94-4b9c-85fb-a0a799d7ae50'
+                $assignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $servicePrincipalId
+                if ($aadGroup.Id -in $assignments.principalId) {
+                    $output = "Require claim `"groups~$($aadGroup.Id)`""
+                }
+                throw "Group not Valid"
+            }
+        }
+        Write-Host $output
+        $output | Out-File "$(Build.ArtifactStagingDirectory)/.htaccess"
+        azurePowerShellVersion: 'LatestVersion'
+    displayName: Create htaccess
+
+  # - bash: |
+  #     FILE=.htaccess
+  #     if test -f "$FILE"; then
+  #       cp $FILE $(Build.ArtifactStagingDirectory)/
+  #     fi
+  #   displayName: copy htaccess
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - ${{ if parameters.DevDeploys }}:

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -86,6 +86,8 @@ jobs:
         $context = Get-AzContext
         $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com")
         write-host $graphToken
+        $graphToken | fl | out-string
+        $graphtoken | fl | out-string | write-host
         Connect-MgGraph -AccessToken $graphToken.AccessToken
 
         $auth = "${{ parameters.AuthSetting }}"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -96,25 +96,25 @@ jobs:
             "valid-user" {
                 $output = "Require valid-user"
             }
-            "pass" {
+            "unauthenticated" {
                 $output = "OIDCUnAuthAction pass"
             }
             "group" {
+                $groupName = "${{ parameters.AuthGroupName }}"
                 $context = Get-AzContext
                 $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
                 Connect-MgGraph -AccessToken $graphToken
-                $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
+                $aadGroup = Get-MgGroup -Filter "DisplayName eq '$groupName'"
                 if (-not $aadGroup) {
-                    Write-Host "##vso[task.logissue type=error]The group $auth could not be found, verify you have specified the correct group name in your azure-pipelines.yml file."
+                    Write-Host "##vso[task.logissue type=error]The group '$groupName' could not be found, verify you have specified the correct group name in your azure-pipelines.yml file."
                     throw "Group not found"
                 }
-                $servicePrincipalId = 'd23effd1-8b94-4b9c-85fb-a0a799d7ae50'
-                $assignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId $servicePrincipalId
+                $assignments = Get-MgServicePrincipalAppRoleAssignedTo -ServicePrincipalId '$(docs-auth-id)'
                 if ($aadGroup.Id -in $assignments.principalId) {
                     $output = "Require claim `"groups~$($aadGroup.Id)`""
                 }
                 else {
-                    Write-Host "##vso[task.logissue type=error]The group $auth is not registered for this application, verify you have specified the correct group name in your azure-pipelines.yml file, and verify with SRE that they have registered the group correctly."
+                    Write-Host "##vso[task.logissue type=error]The group '$groupName' is not registered for this application, verify you have specified the correct group name in your azure-pipelines.yml file, and verify with SRE that they have registered the group correctly."
                     throw "Group not Valid"
                 }
             }

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -83,12 +83,7 @@ jobs:
       azureSubscription: 'docs-publish'
       ScriptType: 'InlineScript'
       Inline: |
-        $context = Get-AzContext
-        $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com")
-        write-host $graphToken
-        $graphToken | fl | out-string
-        $graphtoken | fl | out-string | write-host
-        Connect-MgGraph -AccessToken $graphToken.AccessToken
+
 
         $auth = "${{ parameters.AuthSetting }}"
         # $auth = "valid-user"
@@ -101,6 +96,12 @@ jobs:
                 $output = "OIDCUnAuthAction pass"
             }
             default {
+                $context = Get-AzContext
+                $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com")
+                # write-host $graphToken
+                # $graphToken | fl | out-string
+                # $graphtoken | fl | out-string | write-host
+                Connect-MgGraph -AccessToken $graphToken.AccessToken
                 $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
                 if (-not $aadGroup) {
                     throw "Group not found"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -83,8 +83,6 @@ jobs:
       azureSubscription: 'docs-publish'
       ScriptType: 'InlineScript'
       Inline: |
-
-
         $auth = "${{ parameters.AuthSetting }}"
         # $auth = "valid-user"
 

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -101,6 +101,10 @@ jobs:
             }
             "group" {
                 $groupName = "${{ parameters.AuthGroupName }}"
+                if (-not $groupName) {
+                    Write-Host "##vso[task.logissue type=error]No Group Name was specified, please specify a group name in your azure-pipelines.yml file using the 'AuthGroupName' parameter."
+                    throw "No group specified"
+                }
                 $context = Get-AzContext
                 $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
                 Connect-MgGraph -AccessToken $graphToken

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -109,7 +109,7 @@ jobs:
         }
         Write-Host $output
         $output | Out-File "$(Build.ArtifactStagingDirectory)/.htaccess"
-        azurePowerShellVersion: 'LatestVersion'
+      azurePowerShellVersion: 'LatestVersion'
     displayName: Create htaccess
 
   # - bash: |

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -27,6 +27,13 @@ parameters:
 - name: AuthSetting
   type: string
   default: valid-user
+  values:
+  - valid-user
+  - unauthenticated
+  - group
+- name: AuthGroupName
+  type: string
+  default: ''
 
 jobs:
 - job: build
@@ -92,7 +99,7 @@ jobs:
             "pass" {
                 $output = "OIDCUnAuthAction pass"
             }
-            default {
+            "group" {
                 $context = Get-AzContext
                 $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
                 Connect-MgGraph -AccessToken $graphToken
@@ -110,6 +117,9 @@ jobs:
                     Write-Host "##vso[task.logissue type=error]The group $auth is not registered for this application, verify you have specified the correct group name in your azure-pipelines.yml file, and verify with SRE that they have registered the group correctly."
                     throw "Group not Valid"
                 }
+            }
+            default {
+                throw "invalid AuthSetting"
             }
         }
         Write-Host $output

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -84,7 +84,6 @@ jobs:
       ScriptType: 'InlineScript'
       Inline: |
         $auth = "${{ parameters.AuthSetting }}"
-        # $auth = "valid-user"
 
         switch ($auth) {
             "valid-user" {
@@ -95,11 +94,8 @@ jobs:
             }
             default {
                 $context = Get-AzContext
-                $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com")
-                # write-host $graphToken
-                # $graphToken | fl | out-string
-                # $graphtoken | fl | out-string | write-host
-                Connect-MgGraph -AccessToken $graphToken.AccessToken
+                $graphToken = [Microsoft.Azure.Commands.Common.Authentication.AzureSession]::Instance.AuthenticationFactory.Authenticate($context.Account, $context.Environment, $context.Tenant.Id.ToString(), $null, [Microsoft.Azure.Commands.Common.Authentication.ShowDialog]::Never, $null, "https://graph.microsoft.com").AccessToken
+                Connect-MgGraph -AccessToken $graphToken
                 $aadGroup = Get-MgGroup -Filter "DisplayName eq '$auth'"
                 if (-not $aadGroup) {
                     throw "Group not found"
@@ -118,13 +114,6 @@ jobs:
         $output | Out-File "$(Build.ArtifactStagingDirectory)/.htaccess"
       azurePowerShellVersion: 'LatestVersion'
     displayName: Create htaccess
-
-  # - bash: |
-  #     FILE=.htaccess
-  #     if test -f "$FILE"; then
-  #       cp $FILE $(Build.ArtifactStagingDirectory)/
-  #     fi
-  #   displayName: copy htaccess
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - ${{ if parameters.DevDeploys }}:


### PR DESCRIPTION
~This will copy the .htaccess file from the root of the repository into the root of the built site, before the artifact is saved.~

~Still debating if it makes the most sense to do it here, or to do it in the "deploy" step after the artifact is downloaded.~

This no longer copies .htaccess directly, but generates it from settings passed to the template.
Will generate one of:
`Require valid-user` (Require a valid session)
`OIDCUnAuthAction pass` (No authentication required)
`Require claim "groups~xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxx"` (requires membership in the specified group

Introduces a new parameter, `AuthSetting`, that can be `valid-user`, `unauthenticated`, or `group`.  If `group` is specified, an additional parameter `AuthGroupName` is required.  This will check that the group exists, then check if it is "registered" with the given authentication app.  The app is configured to only release claims for groups that are "registered" with it (to keep the claim size relatively small), so this is required for the auth to actually work.

If no AuthSetting is specified, it defaults to `valid-user`.  Specifying the group also requires a variable group be specified in the consuming azure-pipelines.yml that will include a variable `docs-auth-id` that is the Object ID of the Enterprise Application/Service Principal (not the Application ID).  The docs-publish service connection will need to have the "Directory Reader" role applied to it in AzureAD, to be able to query groups and applications.