### PR TITLE
Material umn

### DIFF
--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -54,10 +54,10 @@ jobs:
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - task: PipAuthenticate@1
     inputs:
-      artifactFeeds: $(docs-theme-feed)
+      artifactFeeds: '$(System.TeamProject)/mkdocs-material-umn'
       onlyAddExtraIndex: true
   - script: |
-      pip install $(docs-theme-package) mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      pip install mkdocs-material-umn mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -24,7 +24,7 @@ jobs:
   steps:
   - checkout: self
     persistCredentials: true
-  - checkout: bajurny/mkdocs-material-umn
+  - checkout: material_umn
   - bash: |
       cat << EOF > .markdownlint-cli2.jsonc
       {

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,9 +22,6 @@ parameters:
 jobs:
 - job: build
   steps:
-  # - checkout: self
-  #   persistCredentials: true
-  # - checkout: material_umn
   - bash: |
       cat << EOF > .markdownlint-cli2.jsonc
       {
@@ -60,14 +57,7 @@ jobs:
       artifactFeeds: $(docs-theme-feed)
       onlyAddExtraIndex: true
   - script: |
-      # git config --global user.email "bajurny@umn.edu"
-      # git config --global user.name "Peter Bajurny"
-      # git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
-      # pip install $(Pipeline.Workspace)/s/mkdocs-material-umn
-      # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
-      pip install $(docs-theme-package) mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
-      # cd $(Pipeline.Workspace)/s/mkdocs-demo
-      # pip install mkdocs-material-umn
+      pip install $(docs-theme-package) mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,9 +22,9 @@ parameters:
 jobs:
 - job: build
   steps:
-  - checkout: self
-    persistCredentials: true
-  - checkout: material_umn
+  # - checkout: self
+  #   persistCredentials: true
+  # - checkout: material_umn
   - bash: |
       cat << EOF > .markdownlint-cli2.jsonc
       {
@@ -37,7 +37,7 @@ jobs:
       cat .markdownlint-cli2.jsonc
 
       sudo npm install markdownlint-cli2 markdownlint-cli2-formatter-junit -g
-      markdownlint-cli2 "$(Pipeline.Workspace)/s/mkdocs-demo/docs/**/*.md"
+      markdownlint-cli2 "docs/**/*.md"
       MDLINT=$?
       echo "return code: $MDLINT"
       case $MDLINT in
@@ -55,14 +55,18 @@ jobs:
       testResultsFormat: JUnit
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
+  - task: PipAuthenticate@1
+    inputs:
+      artifactFeeds: 'OIT Docs/mkdocs-material-umn'
   - script: |
       # git config --global user.email "bajurny@umn.edu"
       # git config --global user.name "Peter Bajurny"
       # git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
-      pip install $(Pipeline.Workspace)/s/mkdocs-material-umn
+      # pip install $(Pipeline.Workspace)/s/mkdocs-material-umn
       # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
       # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
-      cd $(Pipeline.Workspace)/s/mkdocs-demo
+      # cd $(Pipeline.Workspace)/s/mkdocs-demo
+      pip install mkdocs-material-umn
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -55,8 +55,10 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      git clone --branch extends https://github.umn.edu/bajurny/mkdocs-material-umn.git
-      pip install ./mkdocs-material-umn
+      git config --global user.email "bajurny@umn.edu"
+      git config --global user.name "Peter Bajurny"
+      git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
+      pip install "$(Agent.BuildDirectory)/markdownlint-cli"
       # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
       # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -57,7 +57,7 @@ jobs:
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - task: PipAuthenticate@1
     inputs:
-      artifactFeeds: 'OIT Docs/mkdocs-material-umn'
+      artifactFeeds: $(docs-theme-feed)
       onlyAddExtraIndex: true
   - script: |
       # git config --global user.email "bajurny@umn.edu"
@@ -65,9 +65,9 @@ jobs:
       # git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
       # pip install $(Pipeline.Workspace)/s/mkdocs-material-umn
       # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
-      # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      pip install $(docs-theme-package) mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       # cd $(Pipeline.Workspace)/s/mkdocs-demo
-      pip install mkdocs-material-umn
+      # pip install mkdocs-material-umn
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -58,6 +58,7 @@ jobs:
   - task: PipAuthenticate@1
     inputs:
       artifactFeeds: 'OIT Docs/mkdocs-material-umn'
+      onlyAddExtraIndex: true
   - script: |
       # git config --global user.email "bajurny@umn.edu"
       # git config --global user.name "Peter Bajurny"

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -22,6 +22,8 @@ parameters:
 jobs:
 - job: build
   steps:
+  - checkout: self
+    persistCredentials: true
   - bash: |
       cat << EOF > .markdownlint-cli2.jsonc
       {
@@ -53,7 +55,8 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
+      # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -55,7 +55,9 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
+      git clone --branch extends https://github.umn.edu/bajurny/mkdocs-material-umn.git
+      pip install ./mkdocs-material-umn
+      # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
       # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -36,7 +36,7 @@ jobs:
       cat .markdownlint-cli2.jsonc
 
       sudo npm install markdownlint-cli2 markdownlint-cli2-formatter-junit -g
-      markdownlint-cli2 "docs/**/*.md"
+      markdownlint-cli2 "$(Pipeline.Workspace)/s/mkdocs-demo/docs/**/*.md"
       MDLINT=$?
       echo "return code: $MDLINT"
       case $MDLINT in
@@ -55,12 +55,13 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - script: |
-      git config --global user.email "bajurny@umn.edu"
-      git config --global user.name "Peter Bajurny"
-      git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
-      pip install "$(Agent.BuildDirectory)/markdownlint-cli"
+      # git config --global user.email "bajurny@umn.edu"
+      # git config --global user.name "Peter Bajurny"
+      # git clone https://github.umn.edu/bajurny/mkdocs-material-umn.git --single-branch --branch extends "$(Agent.BuildDirectory)/markdownlint-cli"
+      pip install $(Pipeline.Workspace)/s/mkdocs-material-umn
       # pip install "mkdocs-material-umn @ git+https://github.umn.edu/bajurny/mkdocs-material-umn.git@extends"
       # pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      cd $(Pipeline.Workspace)/s/mkdocs-demo
       mkdocs build -d $(Build.ArtifactStagingDirectory)
     displayName: mkdocs-material build
   - publish: $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -24,6 +24,7 @@ jobs:
   steps:
   - checkout: self
     persistCredentials: true
+  - checkout: bajurny/mkdocs-material-umn
   - bash: |
       cat << EOF > .markdownlint-cli2.jsonc
       {


### PR DESCRIPTION
Install material-umn theme during pipeline build

Requires an artifact feed in the project with the name mkdocs-material-umn, and a python package published in it called mkdocs-material-umn