### PR TITLE
Support building docs with hugo in addition to mkdocs

### DIFF
--- a/mkdocs/build-hugo.yml
+++ b/mkdocs/build-hugo.yml
@@ -1,8 +1,29 @@
 steps:
+  - task: PythonScript@0
+    inputs:
+      scriptSource: inline
+      script: |
+        import urllib.request
+        import json
+        import re
+        import os
+
+        hugo_url = 'https://api.github.com/repos/gohugoio/hugo/releases/latest'
+        name_regex = r'hugo_extended.*linux-amd64.deb'
+
+        with urllib.request.urlopen(hugo_url) as response:
+            release = json.load(response)
+
+        assets = release['assets']
+        asset = next((a for a in assets if re.match(name_regex, a['name'])), None)
+
+        with urllib.request.urlopen(asset['browser_download_url']) as response:
+            with open(os.path.join('$(Pipeline.Workspace)', asset['name']) , 'wb') as file:
+                file.write(response.read())
+    displayName: Download Hugo
   - script: |
-      wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_extended_0.111.1_linux-amd64.deb
-      ls
-      sudo dpkg -i hugo*.deb
+      ls $(Pipeline.Workspace)
+      sudo dpkg -i $(Pipeline.Workspace)/hugo*.deb
     displayName: Install Hugo
   - script: |
       hugo --destination $(Build.ArtifactStagingDirectory)

--- a/mkdocs/build-hugo.yml
+++ b/mkdocs/build-hugo.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: |
+      wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_extended_0.111.1_linux-amd64.deb
+      ls
+      sudo dpkg -i hugo*.deb
+    displayName: Install Hugo
+  - script: |
+      hugo --destination $(Build.ArtifactStagingDirectory)
+    displayName: hugo build

--- a/mkdocs/build-mkdocs.yml
+++ b/mkdocs/build-mkdocs.yml
@@ -1,0 +1,9 @@
+steps:
+  - task: PipAuthenticate@1
+    inputs:
+      artifactFeeds: '$(System.TeamProject)/mkdocs-material-umn'
+      onlyAddExtraIndex: true
+  - script: |
+      pip install mkdocs-material-umn mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+      mkdocs build -d $(Build.ArtifactStagingDirectory)
+    displayName: mkdocs-material build

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -71,32 +71,19 @@ jobs:
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
   - ${{ if eq(parameters.BuildEngine, 'mkdocs') }}:
-    - task: PipAuthenticate@1
-      inputs:
-        artifactFeeds: '$(System.TeamProject)/mkdocs-material-umn'
-        onlyAddExtraIndex: true
-    - script: |
-        pip install mkdocs-material-umn mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
-        mkdocs build -d $(Build.ArtifactStagingDirectory)
-      displayName: mkdocs-material build
+    - template: build-mkdocs.yml
   - ${{ elseif eq(parameters.BuildEngine, 'hugo') }}:
-    - script: |
-        wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_extended_0.111.1_linux-amd64.deb
-        ls
-        sudo dpkg -i hugo*.deb
-      displayName: Install Hugo
-    - script: |
-        hugo --destination $(Build.ArtifactStagingDirectory)
-      displayName: hugo build
+    - template: build-hugo.yml
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-- template: deploy-docs.yml
-  parameters:
-    DocsPath: ${{ variables['Build.DefinitionName'] }}
-    CleanDestination: ${{ parameters.CleanDestination }}
-    ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
-    Environment: Dev
-    BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
+- ${{ if parameters.DevDeploys }}:
+  - template: deploy-docs.yml
+    parameters:
+      DocsPath: ${{ variables['Build.DefinitionName'] }}
+      CleanDestination: ${{ parameters.CleanDestination }}
+      ArtifactName: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
+      Environment: Dev
+      BuildCondition: and(succeeded(), eq(${{ parameters.DevDeploys }}, true), startsWith(variables['build.sourceBranchName'], 'dev'))
 - template: deploy-docs.yml
   parameters:
     DocsPath: ${{ variables['Build.DefinitionName'] }}

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -37,10 +37,22 @@ jobs:
       }
       EOF
 
+      if [ ${{ parameters.BuildEngine }} == 'mkdocs' ]
+      then
+        DOCSOURCE='docs'
+      elif [ ${{ parameters.BuildEngine }} == 'hugo' ]
+      then
+        DOCSOURCE='content'
+      else
+       echo failure
+       exit 1
+      fi
+      echo $DOCSOURCE
+
       cat .markdownlint-cli2.jsonc
 
       sudo npm install markdownlint-cli2 markdownlint-cli2-formatter-junit -g
-      markdownlint-cli2 "docs/**/*.md"
+      markdownlint-cli2 "$DOCSOURCE/**/*.md"
       MDLINT=$?
       echo "return code: $MDLINT"
       case $MDLINT in

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -18,6 +18,12 @@ parameters:
 - name: DevDeploys
   type: boolean
   default: false
+- name: BuildEngine
+  type: string
+  default: mkdocs
+  values:
+  - mkdocs
+  - hugo
 
 jobs:
 - job: build
@@ -52,14 +58,24 @@ jobs:
       testResultsFormat: JUnit
       testResultsFiles: '$(Common.TestResultsDirectory)/Test-$(Build.SourceVersion).xml'
       failTaskOnFailedTests: ${{ parameters.FailOnTestFailure }}
-  - task: PipAuthenticate@1
-    inputs:
-      artifactFeeds: '$(System.TeamProject)/mkdocs-material-umn'
-      onlyAddExtraIndex: true
-  - script: |
-      pip install mkdocs-material-umn mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
-      mkdocs build -d $(Build.ArtifactStagingDirectory)
-    displayName: mkdocs-material build
+  - ${{ if eq(parameters.BuildEngine, 'mkdocs') }}:
+    - task: PipAuthenticate@1
+      inputs:
+        artifactFeeds: '$(System.TeamProject)/mkdocs-material-umn'
+        onlyAddExtraIndex: true
+    - script: |
+        pip install mkdocs-material-umn mkdocs-material mkdocs-awesome-pages-plugin mkdocs-git-revision-date-localized-plugin mkdocs-markdownextradata-plugin
+        mkdocs build -d $(Build.ArtifactStagingDirectory)
+      displayName: mkdocs-material build
+  - ${{ elseif eq(parameters.BuildEngine, 'hugo') }}:
+    - script: |
+        wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_0.111.1_linux-arm64.deb
+        ls
+        sudo dpkig -i hugo*.deb
+      displayName: Install Hugo
+    - script: |
+        hugo --destination $(Build.ArtifactStagingDirectory)
+      displayName: hugo build
   - publish: $(Build.ArtifactStagingDirectory)
     artifact: ${{ coalesce(parameters.ArtifactName, variables['Build.DefinitionName']) }}
 - template: deploy-docs.yml

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -71,7 +71,7 @@ jobs:
     - script: |
         wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_0.111.1_linux-arm64.deb
         ls
-        sudo dpkig -i hugo*.deb
+        sudo dpkg -i hugo*.deb
       displayName: Install Hugo
     - script: |
         hugo --destination $(Build.ArtifactStagingDirectory)

--- a/mkdocs/umn-mkdocs.yml
+++ b/mkdocs/umn-mkdocs.yml
@@ -69,7 +69,7 @@ jobs:
       displayName: mkdocs-material build
   - ${{ elseif eq(parameters.BuildEngine, 'hugo') }}:
     - script: |
-        wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_0.111.1_linux-arm64.deb
+        wget https://github.com/gohugoio/hugo/releases/download/v0.111.1/hugo_extended_0.111.1_linux-amd64.deb
         ls
         sudo dpkg -i hugo*.deb
       displayName: Install Hugo


### PR DESCRIPTION
This adds a new parameter (BuildEngine) which specifies which static site generator to use.  It accepts `mkdocs` or `hugo`, and defaults to `mkdocs`, for backwards compatibility.

This will query the github releases for the latest version and install it, then build the site.  To reduce complexity of the template files, conditional template insertion is used, and new build-hugo and build-mkdocs templates have been created.

Because hugo expects markdown files to be in a `content` directory instead of `docs`, the linting step uses the BuildEngine parameter to determine what directory to lint.  

Finally, conditional insertion is used to remove the dev deployment step entirely if devdeploys is false.